### PR TITLE
[documentation] Add some clarification about the base version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
-A custom version of the Ferris Sweep. https://github.com/davidphilipbarr/Sweep
+# Tweaked Sweep Compact
 
-This verison has a tightenend up edge cut and spider web silkscreen. See my video for how to customise these. https://youtu.be/JqpBKuEVinw
+![Screenshot 2022-02-12 180505](https://user-images.githubusercontent.com/27895007/153721097-bd672043-a2b1-445c-9fe2-a1f0b4dc29a5.jpg)
+
+A custom version of the [Ferris Sweep](https://github.com/davidphilipbarr/Sweep).
+
+This verison has a tightenend up edge cut and spider web silkscreen. See [my video](https://youtu.be/JqpBKuEVinw) for how to customise these.
+
+## Notes:
+
++ This version is based on the sweep compact. As such, the two micro-controllers must be installed as pictured above (one facing up, the other facing down).
+    - To avoid this, follow the video instuctions but use the sweep-half-swept as your starting point.
++ New editions of the sweep and some minor updates have been made since this version was made. This version is still functional, but it's recommended to follow the video instructions starting from a more updated base.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27895007/153721531-e8d11940-063a-484c-951a-283228cdf59f.png)

Some users are confused about the micro-controller orientation, and this version is based on a deprecated edition of the sweep. This change aims to add some clarification/fair warning for people that want to build this version.